### PR TITLE
[NO-JIRA] Fix ansible version

### DIFF
--- a/files/seed-debian-9.sh
+++ b/files/seed-debian-9.sh
@@ -39,7 +39,7 @@ apt -o Dpkg::Options::="--force-confold" install \
     python3-pip         \
     -y
 
-pip3 install -U pexpect pyopenssl ndg-httpsclient pyasn1 boto3 ansible
+pip3 install -U pexpect pyopenssl ndg-httpsclient pyasn1 boto3 ansible==4.9.0
 
 # Leaving a custom fact for future idempotency checking
 mkdir -p /etc/ansible/facts.d


### PR DESCRIPTION
Avoid error during cloud-init:
```
Collecting ansible-core<2.13,>=2.12.0 (from ansible)
Could not find a version that satisfies the requirement ansible-core<2.13,>=2.12.0 (from ansible) (from versions: ..., 2.11.6,...)
No matching distribution found for ansible-core<2.13,>=2.12.0 (from ansible)
```

Testé en local sur ma machine.